### PR TITLE
[NOJIRA] Optimize stale workflow runner and schedule

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,7 +1,7 @@
 name: "Close stale issues and PR"
 on:
     schedule:
-        - cron: "0 20 * * *"
+        - cron: "0 9 * * *"
 
 permissions:
     actions: write
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
     stale:
-        runs-on: arc-runner-imprint # could probably run on a way smaller runner
+        runs-on: arc-runner-imprint-tiny
         steps:
             - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10
               with:


### PR DESCRIPTION
## Summary
Optimize the stale workflow by:
1. Using `arc-runner-imprint-tiny` instead of `arc-runner-imprint`
2. Moving execution from 8 PM UTC (peak hours) to 9 AM UTC (off-peak)

## Rationale
- Stale action only makes GitHub API calls - does not need 4-6 CPU/6-8Gi RAM
- 8 PM UTC = 3 PM EST = 12 PM PST (work hours)
- 9 AM UTC = 4 AM EST = 1 AM PST (night time)

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] Monitor next scheduled run for successful execution

Generated with [Claude Code](https://claude.com/claude-code)