### PR TITLE
(FEAT)[SPND-3153] Address the color theme of SDK application

### DIFF
--- a/Sources/ApplicationView.swift
+++ b/Sources/ApplicationView.swift
@@ -8,8 +8,17 @@
 import SwiftUI
 
 struct ApplicationView: View {
+  @Environment(\.colorScheme) var colorScheme
   @Environment(\.presentationMode) var presentationMode
   @ObservedObject var viewModel: ApplicationViewModel
+  
+  private var closeButtonColor: Color {
+    colorScheme == .dark ? Color(red: 0.98, green: 0.98, blue: 0.98) : Color(red: 0.2, green: 0.2, blue: 0.2)
+  }
+  
+  private var backgroundColor: Color {
+    colorScheme == .dark ? Color(red: 0.137, green: 0.137, blue: 0.137) : Color(red: 0.98, green: 0.98, blue: 0.98)
+  }
   
   var body: some View {
     VStack(spacing: 0) {
@@ -35,7 +44,7 @@ struct ApplicationView: View {
           }) {
             Image(systemName: "xmark")
               .frame(width: 48, height: 48)
-              .foregroundColor(Color(red: 0.137, green: 0.137, blue: 0.137))
+              .foregroundColor(closeButtonColor)
               .font(.system(size: 16, weight: .semibold))
           }
           .padding(.trailing, 4)
@@ -45,7 +54,7 @@ struct ApplicationView: View {
       
       WebViewWrapper(viewModel: viewModel)
     }
-    .background(Color.white.ignoresSafeArea())
+    .background(backgroundColor.ignoresSafeArea())
     .onReceive(viewModel.$processState) { newState in
       if newState == .closed {
         dismissView()


### PR DESCRIPTION
<!--- 
Features -> FEAT
Chores -> CHORE
Tests -> TEST
Refactor -> REFACTOR

Title format: (FEAT/CHORE/TEST/REFACTOR)[JIRA-Ticket] Commit message
-->

## Description
<!--- Describe your changes in detail -->

## Screenshots (if appropriate):

| Before        | After (Light Mode)  | After (Dark Mode)  |
|:------------:|:-------------:|:-------------:|
| <img width="539" height="1012" alt="Screenshot 2026-02-24 at 10 57 34" src="https://github.com/user-attachments/assets/af53a32b-6e58-4325-933f-e33d19168156" /> | <img width="539" height="1012" alt="Screenshot 2026-02-24 at 10 53 47" src="https://github.com/user-attachments/assets/e0ee10a4-2495-42a8-8d5e-01c499fdc6da" /> | <img width="539" height="1012" alt="Screenshot 2026-02-24 at 10 53 51" src="https://github.com/user-attachments/assets/a89d7581-308e-4d66-8f2e-23b5ec68ef1a" /> |






<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adapt `ApplicationView` background and close button colors to system color scheme for SDK application in [ApplicationView.swift](https://github.com/Imprint-Tech/imprint-sdk-ios/pull/33/files#diff-7f0457c51b5178e907968279b4d959aa23f70ebd5f19889af5a81ae2b130ae7b)
> Add `@Environment(\.colorScheme)` and route color selection through `ApplicationView.closeButtonColor` and `ApplicationView.backgroundColor`; update the view body to use these computed colors in [ApplicationView.swift](https://github.com/Imprint-Tech/imprint-sdk-ios/pull/33/files#diff-7f0457c51b5178e907968279b4d959aa23f70ebd5f19889af5a81ae2b130ae7b).
>
> #### 📍Where to Start
> Start with the computed properties `ApplicationView.closeButtonColor` and `ApplicationView.backgroundColor` in [ApplicationView.swift](https://github.com/Imprint-Tech/imprint-sdk-ios/pull/33/files#diff-7f0457c51b5178e907968279b4d959aa23f70ebd5f19889af5a81ae2b130ae7b), then review their use in the `body`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fec12cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->