### PR TITLE
Add support for passing in offerConfigUUID 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,62 +1,40 @@
 # Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
-## User settings
 xcuserdata/
-
-## Obj-C/Swift specific
+*.xcscmblueprint
+*.xccheckout
+DerivedData/
+build/
+*.moved-aside
 *.hmap
-
-## App packaging
 *.ipa
 *.dSYM.zip
 *.dSYM
+*.xcuserstate
 
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
 
 # Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
-#
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
-
 .build/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+Package.resolved
 
 # CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
 Pods/
-#
-# Add this line if you want to avoid checking in source code from the Xcode workspace
 *.xcworkspace
 
 # Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
-
 Carthage/Build/
+Carthage/Checkouts/
 
 # fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# OS files
+.DS_Store
+*.swp
+*~

--- a/ImprintTests/ApplicationViewModelTests.swift
+++ b/ImprintTests/ApplicationViewModelTests.swift
@@ -15,7 +15,7 @@ class ApplicationViewModelTests: XCTestCase {
     let url = viewModel.webUrl.absoluteString
     XCTAssertTrue(url.hasPrefix("https://apply.imprint.co/start?"))
     XCTAssertTrue(url.contains("client_secret=test-secret"))
-    XCTAssertFalse(url.contains("offerConfigUUID"))
+    XCTAssertFalse(url.contains("offerConfigUUIDs"))
   }
 
   func testWebUrlWithOfferConfigUUID() {
@@ -28,7 +28,7 @@ class ApplicationViewModelTests: XCTestCase {
 
     let url = viewModel.webUrl.absoluteString
     XCTAssertTrue(url.contains("client_secret=test-secret"))
-    XCTAssertTrue(url.contains("offerConfigUUID=offer-uuid-123"))
+    XCTAssertTrue(url.contains("offerConfigUUIDs=offer-uuid-123"))
   }
 
   func testWebUrlStagingEnvironment() {
@@ -41,7 +41,7 @@ class ApplicationViewModelTests: XCTestCase {
 
     let url = viewModel.webUrl.absoluteString
     XCTAssertTrue(url.hasPrefix("https://apply.stg.imprintapi.co/start?"))
-    XCTAssertTrue(url.contains("offerConfigUUID=stg-offer-uuid"))
+    XCTAssertTrue(url.contains("offerConfigUUIDs=stg-offer-uuid"))
   }
 
   func testWebUrlSandboxEnvironment() {
@@ -54,7 +54,7 @@ class ApplicationViewModelTests: XCTestCase {
 
     let url = viewModel.webUrl.absoluteString
     XCTAssertTrue(url.hasPrefix("https://apply.sbx.imprint.co/start?"))
-    XCTAssertTrue(url.contains("offerConfigUUID=sbx-offer-uuid"))
+    XCTAssertTrue(url.contains("offerConfigUUIDs=sbx-offer-uuid"))
   }
 
   func testConfigurationDefaultsOfferConfigUUIDToNil() {

--- a/ImprintTests/ApplicationViewModelTests.swift
+++ b/ImprintTests/ApplicationViewModelTests.swift
@@ -1,0 +1,64 @@
+//
+//  ApplicationViewModelTests.swift
+//  ImprintTests
+//
+
+import XCTest
+@testable import Imprint
+
+class ApplicationViewModelTests: XCTestCase {
+
+  func testWebUrlWithoutOfferConfigUUID() {
+    let configuration = ImprintConfiguration(clientSecret: "test-secret", environment: .production)
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    let url = viewModel.webUrl.absoluteString
+    XCTAssertTrue(url.hasPrefix("https://apply.imprint.co/start?"))
+    XCTAssertTrue(url.contains("client_secret=test-secret"))
+    XCTAssertFalse(url.contains("offerConfigUUID"))
+  }
+
+  func testWebUrlWithOfferConfigUUID() {
+    let configuration = ImprintConfiguration(
+      clientSecret: "test-secret",
+      environment: .production,
+      offerConfigUUID: "offer-uuid-123"
+    )
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    let url = viewModel.webUrl.absoluteString
+    XCTAssertTrue(url.contains("client_secret=test-secret"))
+    XCTAssertTrue(url.contains("offerConfigUUID=offer-uuid-123"))
+  }
+
+  func testWebUrlStagingEnvironment() {
+    let configuration = ImprintConfiguration(
+      clientSecret: "stg-secret",
+      environment: .staging,
+      offerConfigUUID: "stg-offer-uuid"
+    )
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    let url = viewModel.webUrl.absoluteString
+    XCTAssertTrue(url.hasPrefix("https://apply.stg.imprintapi.co/start?"))
+    XCTAssertTrue(url.contains("offerConfigUUID=stg-offer-uuid"))
+  }
+
+  func testWebUrlSandboxEnvironment() {
+    let configuration = ImprintConfiguration(
+      clientSecret: "sbx-secret",
+      environment: .sandbox,
+      offerConfigUUID: "sbx-offer-uuid"
+    )
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    let url = viewModel.webUrl.absoluteString
+    XCTAssertTrue(url.hasPrefix("https://apply.sbx.imprint.co/start?"))
+    XCTAssertTrue(url.contains("offerConfigUUID=sbx-offer-uuid"))
+  }
+
+  func testConfigurationDefaultsOfferConfigUUIDToNil() {
+    let configuration = ImprintConfiguration(clientSecret: "secret")
+    XCTAssertNil(configuration.offerConfigUUID)
+  }
+}

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -32,7 +32,7 @@ class ApplicationViewModel: ObservableObject {
     var url = "\(host)/start?client_secret=\(configuration.clientSecret)&device-id=\(deviceId)"
 
     if let offerConfigUUID = configuration.offerConfigUUID {
-      url += "&offerConfigUUID=\(offerConfigUUID)"
+      url += "&offerConfigUUIDs=\(offerConfigUUID)"
     }
 
     self.webUrl = URL(string: url)!

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -30,7 +30,11 @@ class ApplicationViewModel: ObservableObject {
     let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""
     
     var url = "\(host)/start?client_secret=\(configuration.clientSecret)&device-id=\(deviceId)"
-    
+
+    if let offerConfigUUID = configuration.offerConfigUUID {
+      url += "&offerConfigUUID=\(offerConfigUUID)"
+    }
+
     self.webUrl = URL(string: url)!
     self.configuration = configuration
   }

--- a/Sources/Imprint.swift
+++ b/Sources/Imprint.swift
@@ -26,9 +26,12 @@ public class ImprintConfiguration {
   /// - Note: This clientSecret is generated through the Post Auth endpoint.
   ///   Please refer to the API documentation (https://docs.imprint.co/api-reference/customer-sessions/create-a-new-customer-session) for details on obtaining a clientSecret.
   let clientSecret: String
-    
+
   /// The environment for the application process, with a default value of `.production`.
   let environment: Environment
+
+  /// An optional offer configuration UUID used to present a specific welcome offer.
+  let offerConfigUUID: String?
   
   /// A closure that handles the terminal state of the application process.
   /// - Parameters:
@@ -45,9 +48,10 @@ public class ImprintConfiguration {
   /// - Parameters:
   ///   - clientSecret: The clientSecret to initiate the application session.
   ///   - environment: The environment to be used, defaulting to `.production`.
-  public init(clientSecret: String, environment: Environment = .production) {
+  public init(clientSecret: String, environment: Environment = .production, offerConfigUUID: String? = nil) {
     self.clientSecret = clientSecret
     self.environment = environment
+    self.offerConfigUUID = offerConfigUUID
   }
   
   /// Available environments for the application process.


### PR DESCRIPTION
Along with a proper `.gitignore` file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `offerConfigUUID` parameter to `ImprintConfiguration` to pass offer config to webUrl
> - Adds an optional `offerConfigUUID` property to `ImprintConfiguration` with a default of `nil`, keeping the public initializer source-compatible.
> - When set, `ApplicationViewModel` appends an `offerConfigUUIDs` query parameter to the constructed `webUrl`.
> - New tests in `ImprintTests/ApplicationViewModelTests.swift` cover URL construction across all environments (production, staging, sandbox) with and without the new parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95d08b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

[SPND-3807]: https://imprint.atlassian.net/browse/SPND-3807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ