### PR TITLE
allow for manual version specification

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,8 +22,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate version format
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ ! "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "ERROR: Version must match format X.Y.Z (e.g., 1.2.3)"
             exit 1
           fi
@@ -35,8 +37,10 @@ jobs:
 
       - name: Set Version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          echo "new_version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "new_version=$INPUT_VERSION" >> $GITHUB_OUTPUT
 
       # Generate changelog from commits since last tag
       - name: Generate Changelog

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,11 +90,22 @@ jobs:
             echo "CHANGELOG_EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Update Podspec Version
+        run: |
+          sed -i '' "s/s.version.*=.*/s.version          = '${{ steps.version.outputs.new_version }}'/" Imprint.podspec
+          git add Imprint.podspec
+          git commit -m "Bump version to ${{ steps.version.outputs.new_version }}"
+          git push origin HEAD
+
       - name: Create Git Tag
         run: |
           NEW_VERSION=${{ steps.version.outputs.new_version }}
           git tag $NEW_VERSION
           git push origin $NEW_VERSION
+
+      - name: Publish to CocoaPods
+        run: |
+          pod trunk push Imprint.podspec --allow-warnings --silent
 
       # Create GitHub Release
       - name: Create GitHub Release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,11 @@ name: CD
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'SDK version to release (e.g., 0.3.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write  # Required for pushing tags and creating GitHub releases
@@ -16,18 +21,22 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Version must match format X.Y.Z (e.g., 1.2.3)"
+            exit 1
+          fi
+
       - name: Configure Git
         run: |
           git config --local user.name "GitHub Actions Bot"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Read current version from podspec
-      - name: Read Current Version
+      - name: Set Version
         id: version
         run: |
-          CURRENT_VERSION=$(grep -m 1 "s.version" Imprint.podspec | sed -E "s/.*= *[\'\"](([0-9]+\.){2}[0-9]+)[\'\"].*/\1/")
-          echo "Using version from podspec: $CURRENT_VERSION"
-          echo "new_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
 
       # Generate changelog from commits since last tag
       - name: Generate Changelog
@@ -81,19 +90,11 @@ jobs:
             echo "CHANGELOG_EOF"
           } >> $GITHUB_OUTPUT
 
-      # Create and push git tag
       - name: Create Git Tag
         run: |
-          set +x
           NEW_VERSION=${{ steps.version.outputs.new_version }}
           git tag $NEW_VERSION
           git push origin $NEW_VERSION
-
-      # Publish to CocoaPods
-      - name: Publish to CocoaPods
-        run: |
-          set +x
-          pod trunk push Imprint.podspec --allow-warnings --silent
 
       # Create GitHub Release
       - name: Create GitHub Release


### PR DESCRIPTION
Allows us to specify the version during the manual workflow dispatch, putting iOS inline with Android.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual version input to CD workflow for iOS pod releases
> - The [cd.yml](.github/workflows/cd.yml) workflow now requires an explicit `version` string input (X.Y.Z format) when triggered via `workflow_dispatch`.
> - A validation step enforces the semantic version format before proceeding.
> - The workflow updates `Imprint.podspec` with the provided version, commits and pushes the change, then tags the repo and publishes to CocoaPods and GitHub Releases using that version.
> - Behavioral Change: the previous automatic version-reading step is replaced; manual runs must always supply a version explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78ff18c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->