### PR TITLE
[NOLINEAR] Add native Apple Wallet provisioning callback

### DIFF
--- a/Compatibility/Imprint.swift
+++ b/Compatibility/Imprint.swift
@@ -1,0 +1,1 @@
+@_exported import ImprintSDKCore

--- a/ImprintTests/ApplicationViewModelTests.swift
+++ b/ImprintTests/ApplicationViewModelTests.swift
@@ -61,4 +61,19 @@ class ApplicationViewModelTests: XCTestCase {
     let configuration = ImprintConfiguration(clientSecret: "secret")
     XCTAssertNil(configuration.offerConfigUUID)
   }
+
+  func testWebUrlWithoutNativeAppleWalletProvisioningHandler() {
+    let configuration = ImprintConfiguration(clientSecret: "test-secret")
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    XCTAssertFalse(viewModel.webUrl.absoluteString.contains("nativeAppleWalletProvisioning"))
+  }
+
+  func testWebUrlWithNativeAppleWalletProvisioningHandler() {
+    let configuration = ImprintConfiguration(clientSecret: "test-secret")
+    configuration.onNativeAppleWalletProvisioning = { _, _ in }
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    XCTAssertTrue(viewModel.webUrl.absoluteString.contains("nativeAppleWalletProvisioning=true"))
+  }
 }

--- a/ImprintTests/ApplicationViewModelTests.swift
+++ b/ImprintTests/ApplicationViewModelTests.swift
@@ -60,6 +60,7 @@ class ApplicationViewModelTests: XCTestCase {
   func testWebUrlWithApplicationBaseURL() {
     let configuration = ImprintConfiguration(
       clientSecret: "preview-secret",
+      environment: .sandbox,
       applicationBaseURL: URL(string: "https://web-application-preview.example.com/")
     )
     let viewModel = ApplicationViewModel(configuration: configuration)
@@ -67,6 +68,7 @@ class ApplicationViewModelTests: XCTestCase {
     let url = viewModel.webUrl.absoluteString
     XCTAssertTrue(url.hasPrefix("https://web-application-preview.example.com/start?"))
     XCTAssertTrue(url.contains("client_secret=preview-secret"))
+    XCTAssertTrue(url.contains("environment=sandbox"))
   }
 
   func testConfigurationDefaultsOfferConfigUUIDToNil() {

--- a/ImprintTests/ApplicationViewModelTests.swift
+++ b/ImprintTests/ApplicationViewModelTests.swift
@@ -57,6 +57,18 @@ class ApplicationViewModelTests: XCTestCase {
     XCTAssertTrue(url.contains("offerConfigUUIDs=sbx-offer-uuid"))
   }
 
+  func testWebUrlWithApplicationBaseURL() {
+    let configuration = ImprintConfiguration(
+      clientSecret: "preview-secret",
+      applicationBaseURL: URL(string: "https://web-application-preview.example.com/")
+    )
+    let viewModel = ApplicationViewModel(configuration: configuration)
+
+    let url = viewModel.webUrl.absoluteString
+    XCTAssertTrue(url.hasPrefix("https://web-application-preview.example.com/start?"))
+    XCTAssertTrue(url.contains("client_secret=preview-secret"))
+  }
+
   func testConfigurationDefaultsOfferConfigUUIDToNil() {
     let configuration = ImprintConfiguration(clientSecret: "secret")
     XCTAssertNil(configuration.offerConfigUUID)

--- a/ImprintTests/WebViewWrapperTests.swift
+++ b/ImprintTests/WebViewWrapperTests.swift
@@ -178,9 +178,9 @@ class WebViewWrapperTests: XCTestCase {
     XCTAssertEqual(viewModel.logoUrl?.absoluteString, "https://example.com/logo.png")
   }
 
-  func testPaymentMethodCreatedInvokesNativeProvisioningAndResumesWebApplicationOnce() {
+  func testNativeAddToWalletButtonHitReportsSuccessToWebApplicationOnce() {
     var receivedData: ImprintConfiguration.CompletionData?
-    var provisioningCompletion: (() -> Void)?
+    var provisioningCompletion: ((ImprintConfiguration.NativeAddToWalletResult) -> Void)?
     let configuration = ImprintConfiguration(clientSecret: "testSecret")
     configuration.onNativeAppleWalletProvisioning = { data, completion in
       receivedData = data
@@ -189,18 +189,19 @@ class WebViewWrapperTests: XCTestCase {
     viewModel = ApplicationViewModel(configuration: configuration)
     coordinator = WebViewWrapper.Coordinator(viewModel: viewModel)
 
-    let webApplicationResumed = expectation(description: "Web application resumed")
-    webApplicationResumed.assertForOverFulfill = true
+    let resultReported = expectation(description: "Native wallet result reported")
+    resultReported.assertForOverFulfill = true
     var evaluatedScripts: [String] = []
     coordinator.evaluateJavaScript = { script in
       evaluatedScripts.append(script)
-      webApplicationResumed.fulfill()
+      resultReported.fulfill()
     }
     let messageBody: [String: Any] = [
       "source": "imprint_web_app",
-      "event_name": "PAYMENT_METHOD_CREATED",
+      "event_name": "NATIVE_ADD_TO_WALLET_BUTTON_HIT",
       "customer_id": "consumer-123",
-      "payment_method_id": "payment-456"
+      "payment_method_id": "payment-456",
+      "type": "apple_wallet"
     ]
     let message = MockWKScriptMessage(
       name: WebViewWrapper.Constants.callbackHandlerName,
@@ -211,23 +212,57 @@ class WebViewWrapperTests: XCTestCase {
 
     XCTAssertEqual(receivedData?["customer_id"] as? String, "consumer-123")
     XCTAssertEqual(receivedData?["payment_method_id"] as? String, "payment-456")
+    XCTAssertEqual(receivedData?["type"] as? String, "apple_wallet")
     XCTAssertNotNil(provisioningCompletion)
     XCTAssertTrue(evaluatedScripts.isEmpty)
 
-    provisioningCompletion?()
-    provisioningCompletion?()
-    wait(for: [webApplicationResumed], timeout: 1)
+    provisioningCompletion?(.succeeded)
+    provisioningCompletion?(.cancelled)
+    wait(for: [resultReported], timeout: 1)
 
     XCTAssertEqual(
       evaluatedScripts,
-      [WebViewWrapper.Constants.nativeAppleWalletProvisioningCompletedScript]
+      [WebViewWrapper.Constants.nativeAddToWalletCompletedScript(result: .succeeded)]
     )
   }
 
-  func testPaymentMethodCreatedIsIgnoredWithoutNativeProvisioningHandler() {
+  func testNativeAddToWalletButtonHitCanReportCancellation() {
+    var provisioningCompletion: ((ImprintConfiguration.NativeAddToWalletResult) -> Void)?
+    let configuration = ImprintConfiguration(clientSecret: "testSecret")
+    configuration.onNativeAppleWalletProvisioning = { _, completion in
+      provisioningCompletion = completion
+    }
+    viewModel = ApplicationViewModel(configuration: configuration)
+    coordinator = WebViewWrapper.Coordinator(viewModel: viewModel)
+
+    let resultReported = expectation(description: "Cancellation reported")
+    coordinator.evaluateJavaScript = { script in
+      XCTAssertEqual(
+        script,
+        WebViewWrapper.Constants.nativeAddToWalletCompletedScript(result: .cancelled)
+      )
+      resultReported.fulfill()
+    }
+    let message = MockWKScriptMessage(
+      name: WebViewWrapper.Constants.callbackHandlerName,
+      body: [
+        "event_name": "NATIVE_ADD_TO_WALLET_BUTTON_HIT",
+        "payment_method_id": "payment-456",
+        "type": "apple_wallet"
+      ]
+    )
+
+    coordinator.userContentController(WKUserContentController(), didReceive: message)
+    provisioningCompletion?(.cancelled)
+
+    wait(for: [resultReported], timeout: 1)
+  }
+
+  func testNativeAddToWalletButtonHitIsIgnoredWithoutHandler() {
     let messageBody: [String: Any] = [
-      "event_name": "PAYMENT_METHOD_CREATED",
-      "payment_method_id": "payment-456"
+      "event_name": "NATIVE_ADD_TO_WALLET_BUTTON_HIT",
+      "payment_method_id": "payment-456",
+      "type": "apple_wallet"
     ]
     let message = MockWKScriptMessage(
       name: WebViewWrapper.Constants.callbackHandlerName,

--- a/ImprintTests/WebViewWrapperTests.swift
+++ b/ImprintTests/WebViewWrapperTests.swift
@@ -222,7 +222,7 @@ class WebViewWrapperTests: XCTestCase {
 
     XCTAssertEqual(
       evaluatedScripts,
-      [WebViewWrapper.Constants.nativeAddToWalletCompletedScript(result: .succeeded)]
+      ["window.dispatchEvent(new CustomEvent('nativeAddToWalletCompleted', { detail: { result: 'succeeded' } }));"]
     )
   }
 
@@ -239,7 +239,7 @@ class WebViewWrapperTests: XCTestCase {
     coordinator.evaluateJavaScript = { script in
       XCTAssertEqual(
         script,
-        WebViewWrapper.Constants.nativeAddToWalletCompletedScript(result: .cancelled)
+        "window.dispatchEvent(new CustomEvent('nativeAddToWalletCompleted', { detail: { result: 'cancelled' } }));"
       )
       resultReported.fulfill()
     }

--- a/ImprintTests/WebViewWrapperTests.swift
+++ b/ImprintTests/WebViewWrapperTests.swift
@@ -177,6 +177,71 @@ class WebViewWrapperTests: XCTestCase {
     // Assert
     XCTAssertEqual(viewModel.logoUrl?.absoluteString, "https://example.com/logo.png")
   }
+
+  func testPaymentMethodCreatedInvokesNativeProvisioningAndResumesWebApplicationOnce() {
+    var receivedData: ImprintConfiguration.CompletionData?
+    var provisioningCompletion: (() -> Void)?
+    let configuration = ImprintConfiguration(clientSecret: "testSecret")
+    configuration.onNativeAppleWalletProvisioning = { data, completion in
+      receivedData = data
+      provisioningCompletion = completion
+    }
+    viewModel = ApplicationViewModel(configuration: configuration)
+    coordinator = WebViewWrapper.Coordinator(viewModel: viewModel)
+
+    let webApplicationResumed = expectation(description: "Web application resumed")
+    webApplicationResumed.assertForOverFulfill = true
+    var evaluatedScripts: [String] = []
+    coordinator.evaluateJavaScript = { script in
+      evaluatedScripts.append(script)
+      webApplicationResumed.fulfill()
+    }
+    let messageBody: [String: Any] = [
+      "source": "imprint_web_app",
+      "event_name": "PAYMENT_METHOD_CREATED",
+      "customer_id": "consumer-123",
+      "payment_method_id": "payment-456"
+    ]
+    let message = MockWKScriptMessage(
+      name: WebViewWrapper.Constants.callbackHandlerName,
+      body: messageBody
+    )
+
+    coordinator.userContentController(WKUserContentController(), didReceive: message)
+
+    XCTAssertEqual(receivedData?["customer_id"] as? String, "consumer-123")
+    XCTAssertEqual(receivedData?["payment_method_id"] as? String, "payment-456")
+    XCTAssertNotNil(provisioningCompletion)
+    XCTAssertTrue(evaluatedScripts.isEmpty)
+
+    provisioningCompletion?()
+    provisioningCompletion?()
+    wait(for: [webApplicationResumed], timeout: 1)
+
+    XCTAssertEqual(
+      evaluatedScripts,
+      [WebViewWrapper.Constants.nativeAppleWalletProvisioningCompletedScript]
+    )
+  }
+
+  func testPaymentMethodCreatedIsIgnoredWithoutNativeProvisioningHandler() {
+    let messageBody: [String: Any] = [
+      "event_name": "PAYMENT_METHOD_CREATED",
+      "payment_method_id": "payment-456"
+    ]
+    let message = MockWKScriptMessage(
+      name: WebViewWrapper.Constants.callbackHandlerName,
+      body: messageBody
+    )
+    var evaluatedScript: String?
+    coordinator.evaluateJavaScript = { evaluatedScript = $0 }
+
+    coordinator.userContentController(WKUserContentController(), didReceive: message)
+
+    XCTAssertNil(evaluatedScript)
+    XCTAssertEqual(viewModel.completionState, .inProgress)
+    XCTAssertNil(viewModel.completionData)
+  }
 }
 
 class MockWKScriptMessage: WKScriptMessage {

--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,15 @@ let package = Package(
         .library(
             name: "Imprint",
             targets: ["Imprint"]
+        ),
+        .library(
+            name: "ImprintSDKCore",
+            targets: ["ImprintSDKCore"]
         )
     ],
     targets: [
         .target(
-            name: "Imprint",
+            name: "ImprintSDKCore",
             path: "Sources",
             exclude: [],
             sources: ["."],
@@ -23,6 +27,11 @@ let package = Package(
             cSettings: [],
             swiftSettings: [],
             linkerSettings: []
+        ),
+        .target(
+            name: "Imprint",
+            dependencies: ["ImprintSDKCore"],
+            path: "Compatibility"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Imprint"]
         ),
         .library(
-            name: "ImprintSDKCore",
+            name: "ImprintApplicationSDK",
             targets: ["ImprintSDKCore"]
         )
     ],

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ Define the completion handler onCompletion to manage the terminal states when th
     }
     ```
 
-To provision the new card with Apple Wallet natively, set `onNativeAppleWalletProvisioning`. The SDK pauses the embedded application after the payment method is created and resumes it when `resumeApplication` is invoked. Always invoke `resumeApplication` when the native flow finishes, including cancellation or failure.
+To provision the new card with Apple Wallet natively, set `onNativeAppleWalletProvisioning`. The SDK invokes the handler when the applicant taps the Add to Apple Wallet button. The callback data includes `payment_method_id` and `type` (`apple_wallet` or `google_wallet`). Report whether provisioning succeeded or was cancelled; the embedded application remains open after receiving the result.
 
 ```swift
-configuration.onNativeAppleWalletProvisioning = { data, resumeApplication in
+configuration.onNativeAppleWalletProvisioning = { data, reportResult in
   guard let paymentMethodID = data["payment_method_id"] as? String else {
-    resumeApplication()
+    reportResult(.cancelled)
     return
   }
 
-  startAppleWalletProvisioning(paymentMethodID: paymentMethodID) {
-    resumeApplication()
+  startAppleWalletProvisioning(paymentMethodID: paymentMethodID) { succeeded in
+    reportResult(succeeded ? .succeeded : .cancelled)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Define the completion handler onCompletion to manage the terminal states when th
     }
     ```
 
+To provision the new card with Apple Wallet natively, set `onNativeAppleWalletProvisioning`. The SDK pauses the embedded application after the payment method is created and resumes it when `resumeApplication` is invoked. Always invoke `resumeApplication` when the native flow finishes, including cancellation or failure.
+
+```swift
+configuration.onNativeAppleWalletProvisioning = { data, resumeApplication in
+  guard let paymentMethodID = data["payment_method_id"] as? String else {
+    resumeApplication()
+    return
+  }
+
+  startAppleWalletProvisioning(paymentMethodID: paymentMethodID) {
+    resumeApplication()
+  }
+}
+```
+
 4. Start the Application flow
 Once you’ve configured the ImprintConfiguration, initiate the application flow by calling ImprintApp.startApplication from your view controller.
     

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 class ApplicationViewModel: ObservableObject {
   let webUrl: URL
   private let configuration: ImprintConfiguration
+  private let nativeAppleWalletProvisioningHandler: ImprintConfiguration.NativeAppleWalletProvisioningHandler?
   
   @Published var logoUrl: URL?
   @Published var completionState: ImprintConfiguration.CompletionState = .inProgress
@@ -17,6 +18,7 @@ class ApplicationViewModel: ObservableObject {
   var completionData: ImprintConfiguration.CompletionData?
   
   init(configuration: ImprintConfiguration) {
+    let nativeAppleWalletProvisioningHandler = configuration.onNativeAppleWalletProvisioning
     var host = ""
     switch configuration.environment {
     case .staging:
@@ -35,8 +37,13 @@ class ApplicationViewModel: ObservableObject {
       url += "&offerConfigUUIDs=\(offerConfigUUID)"
     }
 
+    if nativeAppleWalletProvisioningHandler != nil {
+      url += "&nativeAppleWalletProvisioning=true"
+    }
+
     self.webUrl = URL(string: url)!
     self.configuration = configuration
+    self.nativeAppleWalletProvisioningHandler = nativeAppleWalletProvisioningHandler
   }
   
   func updateLogoUrl(_ url: URL) {
@@ -49,6 +56,17 @@ class ApplicationViewModel: ObservableObject {
   ) {
     self.completionState = state
     self.completionData = data
+  }
+
+  var hasNativeAppleWalletProvisioningHandler: Bool {
+    nativeAppleWalletProvisioningHandler != nil
+  }
+
+  func requestNativeAppleWalletProvisioning(
+    data: ImprintConfiguration.CompletionData,
+    completion: @escaping () -> Void
+  ) {
+    nativeAppleWalletProvisioningHandler?(data, completion)
   }
   
   func onDismiss() {

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -39,6 +39,13 @@ class ApplicationViewModel: ObservableObject {
     
     var url = "\(host)/start?client_secret=\(configuration.clientSecret)&device-id=\(deviceId)"
 
+    // A preview URL cannot communicate its backend tier through its hostname.
+    // Preserve the configured environment so the preview can route API traffic
+    // to the matching backend.
+    if configuration.applicationBaseURL != nil {
+      url += "&environment=\(configuration.environment.queryValue)"
+    }
+
     if let offerConfigUUID = configuration.offerConfigUUID {
       url += "&offerConfigUUIDs=\(offerConfigUUID)"
     }
@@ -77,5 +84,18 @@ class ApplicationViewModel: ObservableObject {
   
   func onDismiss() {
     configuration.onCompletion?(completionState, completionData)
+  }
+}
+
+private extension ImprintConfiguration.Environment {
+  var queryValue: String {
+    switch self {
+    case .staging:
+      return "staging"
+    case .sandbox:
+      return "sandbox"
+    case .production:
+      return "production"
+    }
   }
 }

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -77,7 +77,7 @@ class ApplicationViewModel: ObservableObject {
 
   func requestNativeAppleWalletProvisioning(
     data: ImprintConfiguration.CompletionData,
-    completion: @escaping () -> Void
+    completion: @escaping (ImprintConfiguration.NativeAddToWalletResult) -> Void
   ) {
     nativeAppleWalletProvisioningHandler?(data, completion)
   }

--- a/Sources/ApplicationViewModel.swift
+++ b/Sources/ApplicationViewModel.swift
@@ -19,14 +19,20 @@ class ApplicationViewModel: ObservableObject {
   
   init(configuration: ImprintConfiguration) {
     let nativeAppleWalletProvisioningHandler = configuration.onNativeAppleWalletProvisioning
-    var host = ""
-    switch configuration.environment {
-    case .staging:
-      host = "https://apply.stg.imprintapi.co"
-    case .sandbox:
-      host = "https://apply.sbx.imprint.co"
-    case .production:
-      host = "https://apply.imprint.co"
+    var host: String
+    if let applicationBaseURL = configuration.applicationBaseURL {
+      host = applicationBaseURL.absoluteString.trimmingCharacters(
+        in: CharacterSet(charactersIn: "/")
+      )
+    } else {
+      switch configuration.environment {
+      case .staging:
+        host = "https://apply.stg.imprintapi.co"
+      case .sandbox:
+        host = "https://apply.sbx.imprint.co"
+      case .production:
+        host = "https://apply.imprint.co"
+      }
     }
     
     let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""

--- a/Sources/Imprint.swift
+++ b/Sources/Imprint.swift
@@ -32,6 +32,9 @@ public class ImprintConfiguration {
 
   /// An optional offer configuration UUID used to present a specific welcome offer.
   let offerConfigUUID: String?
+
+  /// An optional application base URL used to load a preview deployment.
+  let applicationBaseURL: URL?
   
   /// A closure that handles the terminal state of the application process.
   /// - Parameters:
@@ -54,10 +57,18 @@ public class ImprintConfiguration {
   /// - Parameters:
   ///   - clientSecret: The clientSecret to initiate the application session.
   ///   - environment: The environment to be used, defaulting to `.production`.
-  public init(clientSecret: String, environment: Environment = .production, offerConfigUUID: String? = nil) {
+  ///   - offerConfigUUID: An optional offer configuration UUID.
+  ///   - applicationBaseURL: An optional application base URL that overrides the environment host.
+  public init(
+    clientSecret: String,
+    environment: Environment = .production,
+    offerConfigUUID: String? = nil,
+    applicationBaseURL: URL? = nil
+  ) {
     self.clientSecret = clientSecret
     self.environment = environment
     self.offerConfigUUID = offerConfigUUID
+    self.applicationBaseURL = applicationBaseURL
   }
   
   /// Available environments for the application process.

--- a/Sources/Imprint.swift
+++ b/Sources/Imprint.swift
@@ -47,10 +47,10 @@ public class ImprintConfiguration {
   ///   - `error`: Triggered when an error occurs during embedded sign up application flow.
   public var onCompletion: ((CompletionState, CompletionData?) -> Void)?
 
-  /// A closure that starts native Apple Wallet provisioning after a payment method is created.
+  /// A closure that handles a native add-to-wallet button tap.
   /// - Parameters:
-  ///   - data: Includes `payment_method_id` and may include additional identifiers.
-  ///   - completion: Invoke exactly once when the native provisioning flow finishes so the application can continue.
+  ///   - data: Includes `payment_method_id` and `type` (`apple_wallet` or `google_wallet`).
+  ///   - completion: Invoke exactly once with the native provisioning result.
   public var onNativeAppleWalletProvisioning: NativeAppleWalletProvisioningHandler?
 
   /// Initializes a new configuration with the specified clientSecret and environment.
@@ -90,8 +90,13 @@ public class ImprintConfiguration {
 
   public typealias NativeAppleWalletProvisioningHandler = (
     _ data: CompletionData,
-    _ completion: @escaping () -> Void
+    _ completion: @escaping (NativeAddToWalletResult) -> Void
   ) -> Void
+
+  public enum NativeAddToWalletResult: String {
+    case succeeded
+    case cancelled
+  }
   
   /// Terminal states for the application process.
   public enum CompletionState: Int {
@@ -103,7 +108,7 @@ public class ImprintConfiguration {
   
   public enum ProcessState: String, Codable {
     case offerAccepted = "OFFER_ACCEPTED"
-    case paymentMethodCreated = "PAYMENT_METHOD_CREATED"
+    case nativeAddToWalletButtonHit = "NATIVE_ADD_TO_WALLET_BUTTON_HIT"
     case rejected = "REJECTED"
     case inProgress = "IN_PROGRESS"
     case closed = "CLOSED" // (New in v0.2) state to handle auto dismissal after reaching terminate state

--- a/Sources/Imprint.swift
+++ b/Sources/Imprint.swift
@@ -44,6 +44,12 @@ public class ImprintConfiguration {
   ///   - `error`: Triggered when an error occurs during embedded sign up application flow.
   public var onCompletion: ((CompletionState, CompletionData?) -> Void)?
 
+  /// A closure that starts native Apple Wallet provisioning after a payment method is created.
+  /// - Parameters:
+  ///   - data: Includes `payment_method_id` and may include additional identifiers.
+  ///   - completion: Invoke exactly once when the native provisioning flow finishes so the application can continue.
+  public var onNativeAppleWalletProvisioning: NativeAppleWalletProvisioningHandler?
+
   /// Initializes a new configuration with the specified clientSecret and environment.
   /// - Parameters:
   ///   - clientSecret: The clientSecret to initiate the application session.
@@ -70,6 +76,11 @@ public class ImprintConfiguration {
   ///   error_code: ErrorCode | null;           // Standardized error code
 
   public typealias CompletionData = [String: Any?]
+
+  public typealias NativeAppleWalletProvisioningHandler = (
+    _ data: CompletionData,
+    _ completion: @escaping () -> Void
+  ) -> Void
   
   /// Terminal states for the application process.
   public enum CompletionState: Int {
@@ -81,6 +92,7 @@ public class ImprintConfiguration {
   
   public enum ProcessState: String, Codable {
     case offerAccepted = "OFFER_ACCEPTED"
+    case paymentMethodCreated = "PAYMENT_METHOD_CREATED"
     case rejected = "REJECTED"
     case inProgress = "IN_PROGRESS"
     case closed = "CLOSED" // (New in v0.2) state to handle auto dismissal after reaching terminate state

--- a/Sources/WebViewWrapper.swift
+++ b/Sources/WebViewWrapper.swift
@@ -15,12 +15,15 @@ struct WebViewWrapper: UIViewRepresentable {
     static let eventName = "event_name"
     static let errorCode = "error_code"
     static let data = "data"
+    static let nativeAppleWalletProvisioningCompletedScript =
+      "window.dispatchEvent(new Event('imprintNativeAppleWalletProvisioningCompleted'));"
   }
   
   @ObservedObject var viewModel: ApplicationViewModel
   
   func makeUIView(context: Context) -> WKWebView {
     let webView = WKWebView()
+    context.coordinator.webView = webView
     webView.navigationDelegate = context.coordinator
     // Enable webView open new window
     webView.uiDelegate = context.coordinator
@@ -41,6 +44,8 @@ struct WebViewWrapper: UIViewRepresentable {
   
   class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
     var viewModel: ApplicationViewModel
+    weak var webView: WKWebView?
+    var evaluateJavaScript: ((String) -> Void)?
     
     init(viewModel: ApplicationViewModel) {
       self.viewModel = viewModel
@@ -55,10 +60,14 @@ struct WebViewWrapper: UIViewRepresentable {
           // load logo on navbar
           viewModel.updateLogoUrl(logoUrl)
           return
-        } else if let eventData = body as? ImprintConfiguration.CompletionData,
-                  let event = eventData[Constants.eventName] as? String,
-                  let state = ImprintConfiguration.ProcessState(rawValue: event){
+        } else if let event = body[Constants.eventName] as? String,
+                  let state = ImprintConfiguration.ProcessState(rawValue: event) {
+          let eventData: ImprintConfiguration.CompletionData = body
           let processedData = processCompletionData(eventData)
+          if state == .paymentMethodCreated {
+            handleNativeAppleWalletProvisioning(processedData)
+            return
+          }
           viewModel.processState = state
           switch state {
           case .offerAccepted:
@@ -71,6 +80,27 @@ struct WebViewWrapper: UIViewRepresentable {
             break
           default:
             viewModel.updateCompletionState(.inProgress, data: processedData)
+          }
+        }
+      }
+    }
+
+    private func handleNativeAppleWalletProvisioning(
+      _ data: ImprintConfiguration.CompletionData
+    ) {
+      guard viewModel.hasNativeAppleWalletProvisioningHandler else { return }
+
+      var hasCompleted = false
+      viewModel.requestNativeAppleWalletProvisioning(data: data) { [weak self] in
+        DispatchQueue.main.async {
+          guard !hasCompleted else { return }
+          hasCompleted = true
+
+          let script = Constants.nativeAppleWalletProvisioningCompletedScript
+          if let evaluateJavaScript = self?.evaluateJavaScript {
+            evaluateJavaScript(script)
+          } else {
+            self?.webView?.evaluateJavaScript(script)
           }
         }
       }

--- a/Sources/WebViewWrapper.swift
+++ b/Sources/WebViewWrapper.swift
@@ -18,7 +18,7 @@ struct WebViewWrapper: UIViewRepresentable {
     static func nativeAddToWalletCompletedScript(
       result: ImprintConfiguration.NativeAddToWalletResult
     ) -> String {
-      "window.dispatchEvent(new CustomEvent('imprintNativeAddToWalletCompleted', { detail: { result: '\(result.rawValue)' } }));"
+      "window.dispatchEvent(new CustomEvent('nativeAddToWalletCompleted', { detail: { result: '\(result.rawValue)' } }));"
     }
   }
   

--- a/Sources/WebViewWrapper.swift
+++ b/Sources/WebViewWrapper.swift
@@ -15,8 +15,11 @@ struct WebViewWrapper: UIViewRepresentable {
     static let eventName = "event_name"
     static let errorCode = "error_code"
     static let data = "data"
-    static let nativeAppleWalletProvisioningCompletedScript =
-      "window.dispatchEvent(new Event('imprintNativeAppleWalletProvisioningCompleted'));"
+    static func nativeAddToWalletCompletedScript(
+      result: ImprintConfiguration.NativeAddToWalletResult
+    ) -> String {
+      "window.dispatchEvent(new CustomEvent('imprintNativeAddToWalletCompleted', { detail: { result: '\(result.rawValue)' } }));"
+    }
   }
   
   @ObservedObject var viewModel: ApplicationViewModel
@@ -64,8 +67,8 @@ struct WebViewWrapper: UIViewRepresentable {
                   let state = ImprintConfiguration.ProcessState(rawValue: event) {
           let eventData: ImprintConfiguration.CompletionData = body
           let processedData = processCompletionData(eventData)
-          if state == .paymentMethodCreated {
-            handleNativeAppleWalletProvisioning(processedData)
+          if state == .nativeAddToWalletButtonHit {
+            handleNativeAddToWallet(processedData)
             return
           }
           viewModel.processState = state
@@ -85,18 +88,18 @@ struct WebViewWrapper: UIViewRepresentable {
       }
     }
 
-    private func handleNativeAppleWalletProvisioning(
+    private func handleNativeAddToWallet(
       _ data: ImprintConfiguration.CompletionData
     ) {
       guard viewModel.hasNativeAppleWalletProvisioningHandler else { return }
 
       var hasCompleted = false
-      viewModel.requestNativeAppleWalletProvisioning(data: data) { [weak self] in
+      viewModel.requestNativeAppleWalletProvisioning(data: data) { [weak self] result in
         DispatchQueue.main.async {
           guard !hasCompleted else { return }
           hasCompleted = true
 
-          let script = Constants.nativeAppleWalletProvisioningCompletedScript
+          let script = Constants.nativeAddToWalletCompletedScript(result: result)
           if let evaluateJavaScript = self?.evaluateJavaScript {
             evaluateJavaScript(script)
           } else {


### PR DESCRIPTION
## Summary

- Add the optional onNativeAppleWalletProvisioning SDK configuration callback.
- Pass payment method data and a one-shot continuation callback to the host application.
- Signal the embedded web application after native provisioning, cancellation, or failure completes.
- Document the integration and cover URL and callback behavior with tests.

## Why

The host iOS application needs to provision the new card with native Apple Wallet APIs before the embedded application continues.

Web application dependency: https://github.com/Imprint-Tech/frontend-js-monorepo/pull/6558

## User impact

Existing integrations are unchanged. Opted-in integrations receive payment method identifiers and control when the embedded flow resumes.

## Validation

- xcodebuild test passed on the iPhone 17 / iOS 26.5 simulator: 17 tests.
- git diff --check passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Apple Wallet provisioning callback to the Imprint SDK
> - Adds `onNativeAppleWalletProvisioning` to `ImprintConfiguration` as a public handler for native Apple Wallet provisioning flows.
> - When the handler is set, `ApplicationViewModel` appends `nativeAppleWalletProvisioning=true` to the web app start URL so the embedded app knows native provisioning is available.
> - A new `PAYMENT_METHOD_CREATED` process state triggers `handleNativeAppleWalletProvisioning` in `WebViewWrapper.Coordinator`, which invokes the handler and pauses further web state updates until the host app calls the completion closure.
> - On completion, the coordinator dispatches an `imprintNativeAppleWalletProvisioningCompleted` JS event to the web view exactly once, even if the completion closure is called multiple times.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a748a41. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->